### PR TITLE
Support computer name for realm command (realm.py)

### DIFF
--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -58,8 +58,7 @@ class F19_Realm(KickstartCommand):
                                                        "membership-software=",
                                                        "one-time-password=",
                                                        "no-password",
-                                                       "computer-ou=",
-                                                       "computer-name="))
+                                                       "computer-ou="))
         except getopt.GetoptError as ex:
             raise KickstartParseError(_("Invalid realm arguments: %s") % ex, lineno=self.lineno)
 
@@ -124,6 +123,11 @@ class F42_Realm(F19_Realm):
 
         if len(remaining) != 1:
             raise KickstartParseError(_("Specify only one realm to join"), lineno=self.lineno)
+        
+        for (o, a) in opts:
+          if o == "--computer-name":
+              if len(a) == 0:
+                  raise KickstartParseError(_("Argument --computer-name must have an argument"), lineno=self.lineno)
 
         # Parse successful, just use this as the join command
         self.join_realm = remaining[0]

--- a/pykickstart/handlers/f42.py
+++ b/pykickstart/handlers/f42.py
@@ -72,7 +72,7 @@ class F42Handler(BaseHandler):
         "partition": commands.partition.F41_Partition,
         "poweroff": commands.reboot.F23_Reboot,
         "raid": commands.raid.F29_Raid,
-        "realm": commands.realm.F19_Realm,
+        "realm": commands.realm.F42_Realm,
         "reboot": commands.reboot.F23_Reboot,
         "repo": commands.repo.F40_Repo,
         "reqpart": commands.reqpart.F23_ReqPart,

--- a/tests/commands/realm.py
+++ b/tests/commands/realm.py
@@ -1,7 +1,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.realm import F19_Realm
-from pykickstart.version import F19
+from pykickstart.version import F19, F42
 
 class Realm_TestCase(unittest.TestCase):
     def runTest(self):
@@ -62,6 +62,17 @@ class F19_MultipleJoin_TestCase(CommandSequenceTest):
         self.assert_parse_error("""
 realm join blah1
 realm join blah2""")
+
+class F42_TestCase(F19_TestCase):
+    def runTest(self):
+        F19_TestCase.runTest(self)
+
+        # Support the --computer-name option
+        self.assert_parse("""realm join --computer-name=blee blah2""")
+
+        # Support the --computer-name option alongside another supported argument 
+        self.assert_parse("""realm join --computer-name=blee --computer-ou=OU=blah blah2""")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/realm.py
+++ b/tests/commands/realm.py
@@ -68,11 +68,13 @@ class F42_TestCase(F19_TestCase):
         F19_TestCase.runTest(self)
 
         # Support the --computer-name option
-        self.assert_parse("""realm join --computer-name=blee blah2""")
+        self.assert_parse("""realm join --computer-name=blee domain.example.com""")
 
         # Support the --computer-name option alongside another supported argument 
-        self.assert_parse("""realm join --computer-name=blee --computer-ou=OU=blah blah2""")
+        self.assert_parse("""realm join --computer-name=blee --computer-ou=OU=blah domain.example.com""")
 
+        # fail - computer name must have argument
+        self.assert_parse_error("""realm join --computer-name= domain.example.com""")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Permit the --computer-name option to the `realm join` command. Used to allow joining where the computer object name does not match the hostname e.g. when directory serves multiple domains and the fqdn needs to be used as the  hostname alone may not be unique.